### PR TITLE
PR  : Initialiser les données COM #21

### DIFF
--- a/importers/noumea/config.yml
+++ b/importers/noumea/config.yml
@@ -1,0 +1,12 @@
+computedFields:
+  - codeCommune
+resources:
+  default:
+    url: https://opendata.arcgis.com/api/v3/datasets/0d8d6931e5bb4e08838072bf3954a938_0/downloads/data?format=geojson&spatialRefId=4326
+    format: geojson
+    fields:
+      numero: numero
+      suffixe: comp_num
+      nomVoie: libvoie
+      lon: _geometry.coordinates.0
+      lat: _geometry.coordinates.1

--- a/importers/noumea/index.js
+++ b/importers/noumea/index.js
@@ -1,0 +1,13 @@
+function codeCommune() {
+  return '38185'
+}
+
+function nomVoie(data) {
+  return [data._default.VOIE_TYPE, data._default.VOIE_ARTICLE, data._default.VOIE_LIBEL]
+    .filter(p => Boolean(p))
+    .join(' ')
+    .replace(/'\s/g, '\'')
+    .replace(/’\s/g, '’')
+}
+
+module.exports = {codeCommune, nomVoie}

--- a/importers/noumea/index.js
+++ b/importers/noumea/index.js
@@ -1,13 +1,5 @@
 function codeCommune() {
-  return '38185'
+  return '98818'
 }
 
-function nomVoie(data) {
-  return [data._default.VOIE_TYPE, data._default.VOIE_ARTICLE, data._default.VOIE_LIBEL]
-    .filter(p => Boolean(p))
-    .join(' ')
-    .replace(/'\s/g, '\'')
-    .replace(/’\s/g, '’')
-}
-
-module.exports = {codeCommune, nomVoie}
+module.exports = {codeCommune}

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "contours:download": "curl http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2019/geojson/communes-100m.geojson.gz | gunzip > communes-100m.json",
+    "contours:download": "curl http://etalab-datasets.geo.data.gouv.fr/contours-administratifs/2022/geojson/communes-100m.geojson.gz | gunzip > communes-100m.json",
     "lint": "xo",
     "build": "node --max_old_space_size=8192 build"
   },

--- a/sources.yml
+++ b/sources.yml
@@ -87,6 +87,10 @@ whiteList:
   - dataset: 609a300e4b0a3815bff75ba2
     url: https://www.pigma.org/datanouvelleaquitaine/dataset/643819e0-6dd8-48b8-b20e-718f8cffe118/resource/cb170a67-986b-48f2-b4da-764fab51042a/download/20210721_v_bal_aitf_1_2.csv
 
+  - name: Adresses de Nouméa
+    importer: noumea
+    slug: noumea
+
 blackList:
   - name: Sixt-sur-Aff
     dataset: 5d1b155b634f41553150048e


### PR DESCRIPTION
Ajout de l'importer Nouméa pour initialiser les données de la BAN sur cette commune.
Lorsqu'on va sur la page des données on tombe sur cette license : https://www.etalab.gouv.fr/wp-content/uploads/2017/04/ETALAB-Licence-Ouverte-v2.0.pdf , qui semble dire qu'on peut donc les importer dans la BAN.