### PR TITLE
Support des langues régionales pour le moissonneur v1

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,8 +24,17 @@ yarn contours:download
 
 ### Production des fichiers
 
+Pour produire la totalité des données
+
 ```bash
 yarn build
+```
+
+Pour produire uniquement les données liées à un slug interne ou un identifiant data.gouv.fr
+
+```bash
+yarn build [slug]
+yarn build [id]
 ```
 
 ## Licence

--- a/build.js
+++ b/build.js
@@ -44,7 +44,7 @@ async function main() {
 
   await db.clear()
 
-  const sourcesToImport = importOnly ? sources.filter(s => s.importer === importOnly) : sources
+  const sourcesToImport = importOnly ? sources.filter(s => s.slug === importOnly || (s.dataset && s.dataset.id === importOnly)) : sources
 
   const datasets = await bluebird.map(sourcesToImport, async source => {
     const interval = setInterval(() => console.log(`processing ${source.meta.title}`), 60000)

--- a/lib/exports/csv.js
+++ b/lib/exports/csv.js
@@ -23,7 +23,9 @@ const CSV_HEADERS = [
   'typePosition',
   'parcelles',
   'licence',
-  'certificationCommune'
+  'certificationCommune',
+  'nomVoieAlt',
+  'lieuDitComplementNomAlt'
 ]
 
 function toCsvBoolean(value) {
@@ -44,6 +46,8 @@ function asCsv(row) {
 
   result.parcelles = row.parcelles ? row.parcelles.join('|') : ''
   result.certificationCommune = toCsvBoolean(row.certificationCommune)
+  result.nomVoieAlt = JSON.stringify(row.nomVoieAlt)
+  result.lieuDitComplementNomAlt = JSON.stringify(row.lieuDitComplementNomAlt)
 
   return result
 }

--- a/lib/importers/bal.js
+++ b/lib/importers/bal.js
@@ -17,7 +17,9 @@ function normalizeRow(row) {
     source: row.parsedValues.source,
     dateMAJ: row.parsedValues.date_der_maj,
     parcelles: row.parsedValues.cad_parcelles || [],
-    certificationCommune: row.parsedValues.certification_commune
+    certificationCommune: row.parsedValues.certification_commune,
+    nomVoieAlt: row.localizedValues.voie_nom,
+    lieuDitComplementNomAlt: row.localizedValues.lieudit_complement_nom
   }
 }
 

--- a/lib/importers/bal.js
+++ b/lib/importers/bal.js
@@ -1,5 +1,5 @@
 const {take} = require('lodash')
-const {validate} = require('@etalab/bal')
+const {validate} = require('@ban-team/validateur-bal')
 
 function normalizeRow(row) {
   return {

--- a/package.json
+++ b/package.json
@@ -12,8 +12,8 @@
     "build": "node --max_old_space_size=8192 build"
   },
   "dependencies": {
+    "@ban-team/validateur-bal": "^2.9.0",
     "@etalab/adresses-util": "^0.7.0",
-    "@etalab/bal": "^2.6.0",
     "@etalab/decoupage-administratif": "^2.0.0",
     "@etalab/fantoir": "^0.12.1",
     "@keyv/sqlite": "^3.5.2",

--- a/yarn.lock
+++ b/yarn.lock
@@ -18,6 +18,29 @@
     esutils "^2.0.2"
     js-tokens "^4.0.0"
 
+"@ban-team/shared-data@^1.0.0":
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/shared-data/-/shared-data-1.0.0.tgz#b45dc45a33ff0f9421ffa876f77f0f4671087e10"
+  integrity sha512-P5qTuSvRkLcDM2Rm6hriLbM4bC15SLTD6i9oquhSSnIbTkt235kmY+ThDTER5DcSircHeKOsQcD/5j0Mluv8SQ==
+
+"@ban-team/validateur-bal@^2.9.0":
+  version "2.9.0"
+  resolved "https://registry.yarnpkg.com/@ban-team/validateur-bal/-/validateur-bal-2.9.0.tgz#09fa914d42bedaf09c8369126ceed1b0a110945e"
+  integrity sha512-Qid9f/9bnYJyBdAt6vlrp43fDXcAl9bxvD9UTTUC7IMZsZXgIcnxyO8LUnjHz358MDraRmljRCb+U+pLAoA6bA==
+  dependencies:
+    "@ban-team/shared-data" "^1.0.0"
+    "@etalab/project-legal" "^0.6.0"
+    blob-to-buffer "^1.2.9"
+    bluebird "^3.7.2"
+    chalk "^4.1.2"
+    chardet "^1.4.0"
+    date-fns "^2.28.0"
+    file-type "^12.4.2"
+    iconv-lite "^0.6.3"
+    lodash "^4.17.21"
+    papaparse "^5.3.2"
+    yargs "^17.5.0"
+
 "@etalab/adresses-util@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@etalab/adresses-util/-/adresses-util-0.7.0.tgz#510ebe53380ad86a5cccee69e167773733395c4f"
@@ -40,22 +63,6 @@
     talisman "^1.1.4"
     written-number "^0.9.1"
 
-"@etalab/bal@^2.6.0":
-  version "2.6.0"
-  resolved "https://registry.yarnpkg.com/@etalab/bal/-/bal-2.6.0.tgz#8146a2d9c16e2825e9d5e8d1a29abbe1a3ce7644"
-  integrity sha512-LAiXIT0gKmjlr4rNPuzKjqxC2OezfG2PdatGKph0SyslyyawGpQNalSnUEPYCd3aZGpwqvEZJstbx9nQkZxv+Q==
-  dependencies:
-    blob-to-buffer "^1.2.9"
-    bluebird "^3.7.2"
-    chalk "^4.1.2"
-    chardet "^1.4.0"
-    date-fns "^2.28.0"
-    file-type "^12.4.2"
-    iconv-lite "^0.6.3"
-    lodash "^4.17.21"
-    papaparse "^5.3.2"
-    yargs "^17.5.0"
-
 "@etalab/decoupage-administratif@^2.0.0":
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@etalab/decoupage-administratif/-/decoupage-administratif-2.0.0.tgz#24ee640070c47e3c62883873c35450197fa5f78c"
@@ -71,6 +78,13 @@
     keyv "^4.1.1"
     leven "^3.1.0"
     lodash "^4.17.21"
+
+"@etalab/project-legal@^0.6.0":
+  version "0.6.0"
+  resolved "https://registry.yarnpkg.com/@etalab/project-legal/-/project-legal-0.6.0.tgz#9932f023b85e91578fb3249e885677cb18ec072d"
+  integrity sha512-GgxpN38fpYRM+yuTw6HyhWYUnZo9Ux/sy9OZ27nblKhf6tW3PvO2Ts2OrYw+D9IzQWonVOl9gyHOsPjX91YhXg==
+  dependencies:
+    proj4 "^2.8.0"
 
 "@gar/promisify@^1.0.1":
   version "1.1.3"
@@ -5903,6 +5917,14 @@ proj4@^2.6.2:
     mgrs "1.0.0"
     wkt-parser "^1.2.4"
 
+proj4@^2.8.0:
+  version "2.8.0"
+  resolved "https://registry.yarnpkg.com/proj4/-/proj4-2.8.0.tgz#b2cb8f3ccd56d4dcc7c3e46155cd02caa804b170"
+  integrity sha512-baC+YcD4xsSqJ+CpCZljj2gcQDhlKb+J+Zjv/2KSBwWNjk4M0pafgQsE+mWurd84tflMIsP+7j7mtIpFDHzQfQ==
+  dependencies:
+    mgrs "1.0.0"
+    wkt-parser "^1.3.1"
+
 promise-inflight@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/promise-inflight/-/promise-inflight-1.0.1.tgz#98472870bf228132fcbdd868129bad12c3c029e3"
@@ -7379,6 +7401,11 @@ wkt-parser@^1.2.4:
   version "1.2.4"
   resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.2.4.tgz#e42ba7b96f13aef82a2da9056e2d87da0fec5393"
   integrity sha512-ZzKnc7ml/91fOPh5bANBL4vUlWPIYYv11waCtWTkl2TRN+LEmBg60Q1MA8gqV4hEp4MGfSj9JiHz91zw/gTDXg==
+
+wkt-parser@^1.3.1:
+  version "1.3.2"
+  resolved "https://registry.yarnpkg.com/wkt-parser/-/wkt-parser-1.3.2.tgz#deeff04a21edc5b170a60da418e9ed1d1ab0e219"
+  integrity sha512-A26BOOo7sHAagyxG7iuRhnKMO7Q3mEOiOT4oGUmohtN/Li5wameeU4S6f8vWw6NADTVKljBs8bzA8JPQgSEMVQ==
 
 word-wrap@~1.2.3:
   version "1.2.3"


### PR DESCRIPTION
Les variantes en langues régionales des champs `voie_nom` et `lieudit_complement_nom` sont désormais extraites des fichiers au format BAL.

Les informations sont ensuite exposées dans les colonnes `nomVoieAlt` et `lieuditComplementNomAlt` de l'export CSV, sous forme JSON pour des raisons de simplicité.