### PR TITLE
Regroupe les fichiers par commune : création du model "revision" et de la collection "communes_revisions".

### DIFF
--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -2,16 +2,93 @@ const {keyBy} = require('lodash')
 const hasha = require('hasha')
 const chalk = require('chalk')
 const {validate} = require('@ban-team/validateur-bal')
+const {groupBy} = require('lodash')
+const Papa = require('papaparse')
 
 const {fetchAllIfUpdated, fetchIfUpdated, resourceToArtefact} = require('./resources')
 const {convert, getResourcesDefinitions} = require('./convert')
 
 const Source = require('./models/source')
 const Harvest = require('./models/harvest')
+const Revision = require('./models/revision')
 
-const {getErrorPercentage} = require('./util/validate-file')
+const {getNbErrors, getErrorPercentage} = require('./util/validate-file')
 const {sendMessage} = require('./util/slack')
 const {signData} = require('./util/signature')
+
+async function getRevisionChanges(sourceId, codeCommune, data, currentRevision) {
+  const currentFileHash = currentRevision?.fileHash
+  const currentDataHash = currentRevision?.dataHash
+  const currentFileId = currentRevision?.fileId
+
+  const rawValues = data.map(d => d.rawValues)
+  const nbRows = rawValues.length
+  const nbRowsWithErrors = getNbErrors(data.map(d => d))
+
+  const dataHash = signData(rawValues)
+  const csvFile = Papa.unparse(rawValues)
+  const file = Buffer.from(csvFile)
+  const newFileHash = hasha(file, {algorithm: 'sha256'})
+
+  if (currentFileHash && newFileHash === currentFileHash) {
+    return {
+      updateStatus: 'unchanged',
+      fileId: currentFileId,
+      fileHash: currentFileHash,
+      dataHash: currentDataHash
+    }
+  }
+
+  if (currentDataHash && currentDataHash === dataHash) {
+    return {
+      updateStatus: 'unchanged',
+      fileId: currentFileId,
+      fileHash: newFileHash,
+      dataHash
+    }
+  }
+
+  const {_id} = await Source.writeFile(sourceId, file, newFileHash, dataHash)
+
+  return {
+    fileId: _id,
+    sourceId,
+    codeCommune,
+    updateStatus: 'updated',
+    fileHash: newFileHash,
+    dataHash,
+    nbRows,
+    nbRowsWithErrors
+  }
+}
+
+async function handleCommunesRevisions(sourceId, data) {
+  const rows = data.rows.map(r => r)
+  const groupedByCommunes = groupBy(rows, row => {
+    if (row.parsedValues.commune_insee) {
+      return row.parsedValues.commune_insee
+    }
+
+    if (row.additionalValues.cle_interop) {
+      return row.additionalValues.cle_interop.codeCommune
+    }
+
+    return 'not-found'
+  })
+
+  await Promise.all(
+    Object.keys(groupedByCommunes).map(async codeCommune => {
+      const currentRevision = await Revision.getRevisionByCommune(codeCommune)
+      const revisionChanges = await getRevisionChanges(
+        sourceId,
+        codeCommune,
+        groupedByCommunes[codeCommune],
+        currentRevision
+      )
+      await (currentRevision ? Revision.update(currentRevision._id, revisionChanges) : Revision.create(revisionChanges))
+    })
+  )
+}
 
 async function handleNewFile({sourceId, newFile, newFileHash, currentFileId, currentFileHash, currentDataHash}) {
   if (!sourceId || !newFile) {
@@ -63,6 +140,8 @@ async function handleNewFile({sourceId, newFile, newFileHash, currentFileId, cur
   }
 
   const {_id} = await Source.writeFile(sourceId, newFile, newFileHash, dataHash)
+
+  await handleCommunesRevisions(sourceId, result)
 
   return {
     updateStatus: 'updated',

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -1,0 +1,21 @@
+const mongo = require('../util/mongo')
+
+async function create(revision) {
+  await mongo.db.collection('communes_revisions').insertOne({
+    _id: new mongo.ObjectId(),
+    ...revision
+  })
+}
+
+async function update(revisionId, changes) {
+  await mongo.db.collection('communes_revisions').updateOne(
+    {_id: revisionId},
+    {$set: {...changes}}
+  )
+}
+
+async function getRevisionByCommune(codeCommune) {
+  return mongo.db.collection('communes_revisions').findOne({codeCommune})
+}
+
+module.exports = {create, update, getRevisionByCommune}

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -6,11 +6,15 @@ function isErroredRow(row) {
   return row.errors.some(({level}) => level === 'E')
 }
 
+function getNbErrors(rows) {
+  return rows.filter(r => isErroredRow(r)).length
+}
+
 function getErrorPercentage(data) {
   const nbRows = data.rows.length
-  const nbFilteredErroredRows = data.rows.filter(r => isErroredRow(r)).length
+  const nbFilteredErroredRows = getNbErrors(data.rows)
 
   return getPercentage(nbFilteredErroredRows, nbRows)
 }
 
-module.exports = {getErrorPercentage}
+module.exports = {getNbErrors, getErrorPercentage}


### PR DESCRIPTION
## Objectif

Cette PR permet de créer un fichier par commune lors du moissonnage.
Après qu'un csv ait été écrit, pour chacune des communes, une vérification des changements est effectuée.
Si des modifications ont été apportées, il y a une nouvelle entrée dans la collection `communes_revisions` suivie de l'écriture d'un fichier par commune.

## Modifications apportées

- Ajout de `getNbErrors` à `validate-file`
- Création du modèle `revision`
- Regroupement des fichier par commune : ajout de `handleCommunesRevisions` à `lib/harvest`

Collection `communes_revisions` :

```js
  {
    _id: ObjectId,
    fileId: ObjectId,
    sourceId: string,
    codeCommune: string,
    updateStatus: string,
    fileHash: string,
    dataHash: string,
    nbRows: int,
    nbRowsWithErrors: int
  }
```