### PR TITLE
Corrige le message d'erreur quand un fichier est rejeté

### DIFF
--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -9,7 +9,7 @@ const {convert, getResourcesDefinitions} = require('./convert')
 const Source = require('./models/source')
 const Harvest = require('./models/harvest')
 
-const {getErrorPercentage} = require('./util/validate-file')
+const {getErrorPercentage, getErrorMessages} = require('./util/validate-file')
 const {sendMessage} = require('./util/slack')
 const {signData} = require('./util/signature')
 
@@ -36,7 +36,7 @@ async function handleNewFile({sourceId, newFile, newFileHash, currentFileId, cur
   if (!result.parseOk) {
     return {
       updateStatus: 'rejected',
-      updateRejectionReason: `Unable to parse CSV file: ${result.parseErrors.join(', ')}`,
+      updateRejectionReason: `Unable to parse CSV file: ${getErrorMessages(result.parseErrors)}`,
       fileHash: newFileHash // On garde fileHash mais on ne stocke pas le fichier problématique
     }
   }

--- a/lib/harvest.js
+++ b/lib/harvest.js
@@ -9,7 +9,7 @@ const {convert, getResourcesDefinitions} = require('./convert')
 const Source = require('./models/source')
 const Harvest = require('./models/harvest')
 
-const {getErrorPercentage, getErrorMessages} = require('./util/validate-file')
+const {getErrorPercentage, getErrorCodes} = require('./util/validate-file')
 const {sendMessage} = require('./util/slack')
 const {signData} = require('./util/signature')
 
@@ -36,7 +36,7 @@ async function handleNewFile({sourceId, newFile, newFileHash, currentFileId, cur
   if (!result.parseOk) {
     return {
       updateStatus: 'rejected',
-      updateRejectionReason: `Unable to parse CSV file: ${getErrorMessages(result.parseErrors)}`,
+      updateRejectionReason: `Unable to parse CSV file: ${getErrorCodes(result.parseErrors)}`,
       fileHash: newFileHash // On garde fileHash mais on ne stocke pas le fichier problématique
     }
   }

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -1,3 +1,5 @@
+const {uniq} = require('lodash')
+
 function getPercentage(value, totalValue) {
   return (value * 100) / totalValue
 }
@@ -13,8 +15,9 @@ function getErrorPercentage(data) {
   return getPercentage(nbFilteredErroredRows, nbRows)
 }
 
-function getErrorMessages(errors) {
-  return errors.map(({message, row}) => `${message} (row: ${row})`).join(', ')
+function getErrorCodes(errors) {
+  const errorCodes = [...new Set(errors.map(({code}) => code))]
+  return uniq(errorCodes).join(', ')
 }
 
-module.exports = {getErrorPercentage, getErrorMessages}
+module.exports = {getErrorPercentage, getErrorCodes}

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -13,4 +13,8 @@ function getErrorPercentage(data) {
   return getPercentage(nbFilteredErroredRows, nbRows)
 }
 
-module.exports = {getErrorPercentage}
+function getErrorMessages(errors) {
+  return errors.map(({message, row}) => `${message} (row: ${row})`).join(', ')
+}
+
+module.exports = {getErrorPercentage, getErrorMessages}


### PR DESCRIPTION
À l'heure actuelle, le message d'erreur n'est pas retourné correctement quand un fichier est rejeté à cause du "parsing".

- Ajout de la fonction `getErrorMessages` dans `lib/validate-file`