### PR TITLE
Correction du message d'erreur lors du rejet d'un fichier

### DIFF
--- a/lib/harvest/handle-new-file.js
+++ b/lib/harvest/handle-new-file.js
@@ -3,7 +3,7 @@ const {validate} = require('@ban-team/validateur-bal')
 
 const File = require('../models/file')
 
-const {getErrorPercentage, getErrorCodes} = require('../util/validate-file')
+const {getErrorPercentage, getParsingErrorCodes} = require('../util/validate-file')
 const {signData} = require('../util/signature')
 
 const handleCommunesData = require('./handle-communes-data')
@@ -31,7 +31,7 @@ async function handleNewFile({sourceId, harvestId, newFile, newFileHash, current
   if (!result.parseOk) {
     return {
       updateStatus: 'rejected',
-      updateRejectionReason: `Unable to parse CSV file: ${getErrorCodes(result.parseErrors)}`,
+      updateRejectionReason: `Unable to parse CSV file: ${getParsingErrorCodes(result).join(', ')}`,
       fileHash: newFileHash // On garde fileHash mais on ne stocke pas le fichier problématique
     }
   }

--- a/lib/harvest/handle-new-file.js
+++ b/lib/harvest/handle-new-file.js
@@ -3,7 +3,7 @@ const {validate} = require('@ban-team/validateur-bal')
 
 const File = require('../models/file')
 
-const {getErrorPercentage} = require('../util/validate-file')
+const {getErrorPercentage, getErrorCodes} = require('../util/validate-file')
 const {signData} = require('../util/signature')
 
 const handleCommunesData = require('./handle-communes-data')
@@ -31,7 +31,7 @@ async function handleNewFile({sourceId, harvestId, newFile, newFileHash, current
   if (!result.parseOk) {
     return {
       updateStatus: 'rejected',
-      updateRejectionReason: `Unable to parse CSV file: ${result.parseErrors.join(', ')}`,
+      updateRejectionReason: `Unable to parse CSV file: ${getErrorCodes(result.parseErrors)}`,
       fileHash: newFileHash // On garde fileHash mais on ne stocke pas le fichier problématique
     }
   }

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -1,5 +1,3 @@
-const {uniq} = require('lodash')
-
 function getPercentage(value, totalValue) {
   return (value * 100) / totalValue
 }
@@ -16,8 +14,7 @@ function getErrorPercentage(data) {
 }
 
 function getParsingErrorCodes(data) {
-  const errorCodes = [...new Set(data.parseErrors.map(({code}) => code))]
-  return uniq(errorCodes)
+  return [...new Set(data.parseErrors.map(({code}) => code))]
 }
 
 module.exports = {getErrorPercentage, isErroredRow, getParsingErrorCodes}

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -15,9 +15,9 @@ function getErrorPercentage(data) {
   return getPercentage(nbFilteredErroredRows, nbRows)
 }
 
-function getErrorCodes(errors) {
-  const errorCodes = [...new Set(errors.map(({code}) => code))]
-  return uniq(errorCodes).join(', ')
+function getParsingErrorCodes(data) {
+  const errorCodes = [...new Set(data.parseErrors.map(({code}) => code))]
+  return uniq(errorCodes)
 }
 
-module.exports = {getErrorPercentage, isErroredRow, getErrorCodes}
+module.exports = {getErrorPercentage, isErroredRow, getParsingErrorCodes}

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -1,3 +1,5 @@
+const {uniq} = require('lodash')
+
 function getPercentage(value, totalValue) {
   return (value * 100) / totalValue
 }
@@ -13,4 +15,9 @@ function getErrorPercentage(data) {
   return getPercentage(nbFilteredErroredRows, nbRows)
 }
 
-module.exports = {getErrorPercentage, isErroredRow}
+function getErrorCodes(errors) {
+  const errorCodes = [...new Set(errors.map(({code}) => code))]
+  return uniq(errorCodes).join(', ')
+}
+
+module.exports = {getErrorPercentage, isErroredRow, getErrorCodes}


### PR DESCRIPTION
À l'heure actuelle, le message d'erreur n'est pas retourné correctement quand un fichier est rejeté à cause du "parsing".
- Ajout de la fonction `getErrorCodes` dans `lib/util/validate-file`