### PR TITLE
Corrige l'erreur lors de l'absence du code commune

### DIFF
--- a/lib/harvest/handle-communes-data.js
+++ b/lib/harvest/handle-communes-data.js
@@ -7,7 +7,7 @@ const Revision = require('../models/revision')
 const File = require('../models/file')
 
 function getCodeCommune(row) {
-  return row.parsedValues.commune_insee || row.additionalValues.cle_interop.codeCommune
+  return row.parsedValues.commune_insee || row.additionalValues.cle_interop?.codeCommune
 }
 
 async function handleCommuneData({codeCommune, currentRevision, sourceId, harvestId, rows}) {


### PR DESCRIPTION
Une erreur est présente dans les logs lors du moissonnage :
`Cannot read properties of undefined (reading 'codeCommune')`

Cette PR corrige le bug