### PR TITLE
Publication sur l'API de dépôt

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,3 +3,6 @@ MONGODB_DBNAME=moissonneur-bal
 SLACK_TOKEN=
 SLACK_CHANNEL=
 ADMIN_TOKEN=
+API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot
+API_DEPOT_CLIENT_SECRET=
+API_DEPOT_CLIENT_ID=

--- a/lib/harvest/handle-communes-data.js
+++ b/lib/harvest/handle-communes-data.js
@@ -1,10 +1,11 @@
-const {keyBy, groupBy, countBy} = require('lodash')
+const {keyBy, groupBy, countBy, chain} = require('lodash')
 const pMap = require('p-map')
 const Papa = require('papaparse')
 const {signData} = require('../util/signature')
 const {isErroredRow} = require('../util/validate-file')
 const Revision = require('../models/revision')
 const File = require('../models/file')
+const publishBal = require('./publish-bal')
 
 function getCodeCommune(row) {
   return row.parsedValues.commune_insee || row.additionalValues.cle_interop.codeCommune
@@ -15,6 +16,7 @@ async function handleCommuneData({codeCommune, currentRevision, sourceId, harves
 
   const nbRows = rows.length
   const nbRowsWithErrors = rows.length - validRows.length
+  const uniqueErrors = chain(rows).map('errors').flatten().filter(e => e.level === 'E').map('code').uniq().value()
 
   const newRevision = {
     sourceId,
@@ -54,6 +56,20 @@ async function handleCommuneData({codeCommune, currentRevision, sourceId, harves
   newRevision.updateStatus = 'updated'
   newRevision.fileId = fileId
   newRevision.dataHash = dataHash
+
+  try {
+    newRevision.publication = await publishBal({
+      sourceId,
+      codeCommune,
+      harvestId,
+      nbRows,
+      nbRowsWithErrors,
+      validRows,
+      uniqueErrors
+    })
+  } catch (error) {
+    newRevision.publication = {status: 'error', errorMessage: error.message}
+  }
 
   return Revision.createRevision(newRevision)
 }

--- a/lib/harvest/handle-communes-data.js
+++ b/lib/harvest/handle-communes-data.js
@@ -2,7 +2,6 @@ const {keyBy, groupBy, countBy, chain} = require('lodash')
 const pMap = require('p-map')
 const Papa = require('papaparse')
 const {signData} = require('../util/signature')
-const {isErroredRow} = require('../util/validate-file')
 const Revision = require('../models/revision')
 const File = require('../models/file')
 const publishBal = require('./publish-bal')
@@ -12,7 +11,7 @@ function getCodeCommune(row) {
 }
 
 async function handleCommuneData({codeCommune, currentRevision, sourceId, harvestId, rows}) {
-  const validRows = rows.filter(r => !isErroredRow(r))
+  const validRows = rows.filter(r => r.isValid)
 
   const nbRows = rows.length
   const nbRowsWithErrors = rows.length - validRows.length
@@ -78,7 +77,7 @@ async function handleCommunesData({sourceId, harvestId, rows}) {
   const currentRevisions = await Revision.getCurrentRevisions(sourceId)
   const currentRevisionsIndex = keyBy(currentRevisions, 'codeCommune')
 
-  const validRows = rows.filter(r => !isErroredRow(r))
+  const validRows = rows.filter(r => r.isValid)
   const codesCommunes = [...new Set(validRows.map(r => getCodeCommune(r)))]
   const rowsWithCodeCommune = rows.filter(r => getCodeCommune(r))
   const rowsGroups = groupBy(rowsWithCodeCommune, r => getCodeCommune(r))

--- a/lib/harvest/publish-bal.js
+++ b/lib/harvest/publish-bal.js
@@ -1,0 +1,43 @@
+const process = require('process')
+const Papa = require('papaparse')
+
+const {ObjectId} = require('../util/mongo')
+const {getCurrentRevision, publishNewRevision} = require('../util/api-depot')
+
+const {API_DEPOT_CLIENT_ID} = process.env
+
+async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithErrors, validRows, uniqueErrors}) {
+  if (!API_DEPOT_CLIENT_ID) {
+    return {status: 'not-configured'}
+  }
+
+  const currentPublishedRevision = await getCurrentRevision(codeCommune)
+
+  if (currentPublishedRevision && currentPublishedRevision.client.id !== API_DEPOT_CLIENT_ID) {
+    return {status: 'provided-by-other-client', currentClientId: currentPublishedRevision.client.id}
+  }
+
+  if (currentPublishedRevision && currentPublishedRevision.extras.sourceId !== sourceId.toString()) {
+    return {status: 'provided-by-other-source', currentSourceId: new ObjectId(currentPublishedRevision.client.id)}
+  }
+
+  try {
+    const csvContent = Papa.unparse(validRows.map(r => r.rawValues), {delimiter: ';'})
+    const balFile = Buffer.from(csvContent)
+
+    const extras = {
+      sourceId,
+      harvestId,
+      nbRows,
+      nbRowsWithErrors,
+      uniqueErrors
+    }
+
+    const publishedRevision = await publishNewRevision({codeCommune, extras, balFile})
+    return {status: 'published', publishedRevisionId: publishedRevision._id}
+  } catch (error) {
+    return {status: 'error', errorMessage: error.message}
+  }
+}
+
+module.exports = publishBal

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -4,7 +4,7 @@ function getCurrentRevisions(sourceId) {
   return mongo.db.collection('revisions').find({sourceId, current: true})
 }
 
-async function createRevision({sourceId, codeCommune, harvestId, updateStatus, updateRejectionReason, fileId, dataHash, nbRows, nbRowsWithErrors}) {
+async function createRevision({sourceId, codeCommune, harvestId, updateStatus, updateRejectionReason, fileId, dataHash, nbRows, nbRowsWithErrors, publication}) {
   const newRevision = {
     sourceId,
     codeCommune,
@@ -15,6 +15,7 @@ async function createRevision({sourceId, codeCommune, harvestId, updateStatus, u
     dataHash,
     nbRows,
     nbRowsWithErrors,
+    publication,
     current: ['updated', 'unchanged'].includes(updateStatus)
   }
 

--- a/lib/models/source.js
+++ b/lib/models/source.js
@@ -20,9 +20,9 @@ async function upsert(source) {
       $set: {
         ...source,
         _deleted: false,
-        enabled: true
       },
       $setOnInsert: {
+        enabled: true,
         _created: now,
         harvesting: {
           lastHarvest: new Date('1970-01-01'),

--- a/lib/util/api-depot.js
+++ b/lib/util/api-depot.js
@@ -1,0 +1,72 @@
+const got = require('got')
+const hasha = require('hasha')
+const createError = require('http-errors')
+
+const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const {API_DEPOT_CLIENT_SECRET} = process.env
+
+async function getCurrentRevision(codeCommune) {
+  const response = await got(
+    `${API_DEPOT_URL}/communes/${codeCommune}/current-revision`,
+    {responseType: 'json', throwHttpErrors: false}
+  )
+
+  if (response.statusCode === 200) {
+    return response.body
+  }
+
+  if (response.statusCode === 404) {
+    return
+  }
+
+  throw new Error(response.body.message)
+}
+
+async function publishNewRevision({codeCommune, extras, balFile}) {
+  const defaultHeaders = {
+    Authorization: `Token ${API_DEPOT_CLIENT_SECRET}`
+  }
+
+  const revision = await got.post(
+    `${API_DEPOT_URL}/communes/${codeCommune}/revisions`,
+    {
+      json: {context: {extras}},
+      headers: defaultHeaders
+    }
+  ).json()
+
+  await got.put(
+    `${API_DEPOT_URL}/revisions/${revision._id}/files/bal`,
+    {
+      body: balFile,
+      headers: {
+        ...defaultHeaders,
+        'Content-Type': 'application/csv',
+        'Content-MD5': hasha(balFile, {algorithm: 'md5'})
+      }
+    }
+  ).json()
+
+  const computedRevision = await got.post(
+    `${API_DEPOT_URL}/revisions/${revision._id}/compute`,
+    {
+      headers: defaultHeaders
+    }
+  ).json()
+
+  if (!computedRevision.validation.valid) {
+    console.log(computedRevision.validation.errors)
+    throw createError(417, 'Fichier BAL non valide')
+  }
+
+  const publishedRevision = await got.post(
+    `${API_DEPOT_URL}/revisions/${revision._id}/publish`,
+    {
+      headers: defaultHeaders
+    }
+  ).json()
+
+  return publishedRevision
+}
+
+module.exports = {getCurrentRevision, publishNewRevision}

--- a/lib/util/validate-file.js
+++ b/lib/util/validate-file.js
@@ -2,15 +2,11 @@ function getPercentage(value, totalValue) {
   return (value * 100) / totalValue
 }
 
-function isErroredRow(row) {
-  return row.errors.some(({level}) => level === 'E')
-}
-
 function getErrorPercentage(data) {
   const nbRows = data.rows.length
-  const nbFilteredErroredRows = data.rows.filter(r => isErroredRow(r)).length
+  const nbFilteredErroredRows = data.rows.filter(r => !r.isValid).length
 
   return getPercentage(nbFilteredErroredRows, nbRows)
 }
 
-module.exports = {getErrorPercentage, isErroredRow}
+module.exports = {getErrorPercentage}


### PR DESCRIPTION
Implémentation du mécanisme de publication sur l'API de dépôt :

Je regarde la révision publiée actuellement sur l'API.
Si celle-ci a été publiée par un autre outil que le moissonneur, on ignore avec `status: 'provided-by-other-client'`.
Si celle-ci a été publiée par le moissonneur mais via une autre source de données, on ignore avec `status: 'provided-by-other-source'`.

Si la commune ne dispose pas de révision en vigueur ou si celle-ci provient du moissonneur et de la même source : on publie.

La publication consiste en la production d'un fichier expurgé des lignes en erreurs puisque l'API de dépôt ne supporte pas les fichiers contenant des erreurs.
On publie aussi des métadonnées utiles dans `extras`.
Le statut final est `status: 'published'`.