### PR TITLE
Corrige l'erreur quand l'url d'une source est null

### DIFF
--- a/lib/resources/ods.js
+++ b/lib/resources/ods.js
@@ -2,7 +2,7 @@ const {trim} = require('lodash')
 const got = require('got')
 
 function isOds(url) {
-  return url.includes('/explore/dataset') && url.includes('/download') && url.includes('format=')
+  return url?.includes('/explore/dataset') && url?.includes('/download') && url?.includes('format=')
 }
 
 async function getODSInfo(url) {


### PR DESCRIPTION
Les logs renvoient une erreur quand la source n'a pas d'url :
`Cannot read property 'includes' of null`

- Modification de la fonction `isOds`

