### PR TITLE
Ajout d'une API de publication

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ yarn start
 ## Documentation API
 
 Les requêtes nécessitant un jeton doivent utiliser l'en-tête HTTP `Authorization`
->Exemple : 
+>Exemple :
 >`Authorization: Token f66gdjfehfv66DBD`
 
 ### Points d'accès
@@ -70,6 +70,12 @@ Les requêtes nécessitant un jeton doivent utiliser l'en-tête HTTP `Authorizat
 
 ### `/harvests/{harvestId}/revisions`
 - `GET` : Liste les révisions d'un moissonnage
+
+### `/revisions/{revisionId}`
+- `GET` : Retourne les informations concernant une révision
+
+### `/revisions/{revisionId}/publish`
+- `POST` : Déclenche la publication d'une révision *
 
 ### `/files/{fileId}/download`
 - `GET` : Télécharge un fichier un fonction de son id

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -1,4 +1,10 @@
+const createError = require('http-errors')
+const {validate} = require('@ban-team/validateur-bal')
+
 const mongo = require('../util/mongo')
+const publishBal = require('../harvest/publish-bal')
+
+const Source = require('./source')
 
 function getCurrentRevisions(sourceId) {
   return mongo.db.collection('revisions').find({sourceId, current: true}).toArray()
@@ -36,4 +42,65 @@ async function createRevision({sourceId, codeCommune, harvestId, updateStatus, u
   return newRevision
 }
 
-module.exports = {getCurrentRevisions, createRevision, getRevisions}
+async function publish(revision) {
+  const {sourceId, codeCommune, harvestId, nbRows, nbRowsWithErrors, uniqueErrors, fileId, current} = revision
+  const publication = revision.publication || {}
+  const source = await Source.getSource(sourceId)
+
+  if (!current) {
+    throw createError(409, 'La révision n’est pas la révision courante pour cette commune')
+  }
+
+  if (!['published', 'provided-by-other-client', 'provided-by-other-source'].includes(publication.status)) {
+    throw createError(409, 'La révision ne peut pas être publiée')
+  }
+
+  if (!source) {
+    throw createError(409, 'La source associée n’existe plus')
+  }
+
+  if (!source.enabled) {
+    throw createError(409, 'La source associée n’est plus active')
+  }
+
+  if (source._deleted) {
+    throw createError(409, 'La source associée a été supprimée')
+  }
+
+  let file = null
+  try {
+    file = await mongo.getFile(fileId)
+  } catch {
+    throw createError(409, 'Le fichier BAL associé n’est plus disponible')
+  }
+
+  const result = await validate(file, {relaxFieldsDetection: true})
+
+  if (!result.parseOk || result.rows.length !== nbRows) {
+    throw createError(409, 'Problème de cohérence des données : investigation nécessaire')
+  }
+
+  const validRows = result.rows.filter(r => r.isValid)
+  const organizationName = source.organization?.name
+
+  const publicationResult = await publishBal({
+    sourceId,
+    codeCommune,
+    harvestId,
+    nbRows,
+    nbRowsWithErrors,
+    validRows,
+    uniqueErrors,
+    organizationName
+  })
+
+  const {value} = await mongo.db.collection('revisions').findOneAndUpdate(
+    {_id: revision._id},
+    {$set: {publication: publicationResult}},
+    {returnDocument: 'after'}
+  )
+
+  return value
+}
+
+module.exports = {getCurrentRevisions, createRevision, getRevisions, publish}

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -14,6 +14,10 @@ function getRevisions(harvestId) {
   return mongo.db.collection('revisions').find({harvestId}).toArray()
 }
 
+function getRevision(revisionId) {
+  return mongo.db.collections('revisions').findOne({_id: revisionId})
+}
+
 async function createRevision({sourceId, codeCommune, harvestId, updateStatus, updateRejectionReason, fileId, dataHash, nbRows, nbRowsWithErrors, uniqueErrors, publication}) {
   const newRevision = {
     sourceId,
@@ -103,4 +107,4 @@ async function publish(revision) {
   return value
 }
 
-module.exports = {getCurrentRevisions, createRevision, getRevisions, publish}
+module.exports = {getCurrentRevisions, createRevision, getRevisions, getRevision, publish}

--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -4,6 +4,7 @@ const intoStream = require('into-stream')
 const createError = require('http-errors')
 const contentDisposition = require('content-disposition')
 const finished = promisify(require('stream').finished)
+const getStream = require('get-stream')
 
 const MONGODB_URL = process.env.MONGODB_URL || 'mongodb://localhost'
 const MONGODB_DBNAME = process.env.MONGODB_DBNAME || 'moissonneur-bal'
@@ -47,6 +48,16 @@ class Mongo {
     res.set('Content-Disposition', contentDisposition(fileRecord.filename))
     res.set('Content-Length', fileRecord.length)
     this.bucket.openDownloadStream(_id).pipe(res)
+  }
+
+  async getFile(fileId) {
+    const fileRecord = await this.db.collection('fs.files').findOne({_id: fileId})
+
+    if (!fileRecord) {
+      throw new Error('Fichier introuvable')
+    }
+
+    return getStream(this.bucket.openDownloadStream(fileId))
   }
 
   async createIndexes() {

--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     "express": "^4.18.1",
     "fast-json-stable-stringify": "^2.1.0",
     "gdal-async": "^3.5.1",
+    "get-stream": "^6.0.1",
     "got": "^11.8.5",
     "hasha": "^5.2.2",
     "http-errors": "^2.0.0",

--- a/server.js
+++ b/server.js
@@ -64,6 +64,23 @@ async function main() {
     next()
   }))
 
+  app.param('revisionId', w(async (req, res, next) => {
+    const revisionId = mongo.parseObjectID(req.params.revisionId)
+
+    if (!revisionId) {
+      throw createError(404, 'Identifiant non valide')
+    }
+
+    const revision = await Revision.getRevision(revisionId)
+
+    if (!revision) {
+      throw createError(404, 'Révision non trouvée')
+    }
+
+    req.revision = revision
+    next()
+  }))
+
   app.post('/sources/:sourceId/harvest', ensureIsAdmin, w(async (req, res) => {
     if (req.source.harvesting.asked) {
       throw createError(404, 'Moissonnage déjà demandé')

--- a/server.js
+++ b/server.js
@@ -130,6 +130,15 @@ async function main() {
     res.send(revisions)
   }))
 
+  app.get('/revisions/:revisionId', (req, res) => {
+    res.send(req.revision)
+  })
+
+  app.post('/revisions/:revisionId/publish', ensureIsAdmin, w(async (req, res) => {
+    const revision = await Revision.publish(req.revision)
+    res.send(revision)
+  }))
+
   app.get('/files/:fileId/download', w(async (req, res) => {
     await mongo.sendFile(req.params.fileId, res)
   }))

--- a/yarn.lock
+++ b/yarn.lock
@@ -2674,7 +2674,7 @@ get-stream@^5.1.0:
   dependencies:
     pump "^3.0.0"
 
-get-stream@^6.0.0:
+get-stream@^6.0.0, get-stream@^6.0.1:
   version "6.0.1"
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==


### PR DESCRIPTION
Cette API permet de publier une révision qui ne l'a pas été automatiquement, ou de re-publier une révision qui a été replacée par une autre.

L'action n'est possible que sur les révisions "courantes" au sens d'une source, pour les sources actives et non supprimées.
Il faut aussi que le précédent statut de publication soit compatible.