### PR TITLE
Corrige la récupération de sourceId pour la publication

### DIFF
--- a/lib/harvest/publish-bal.js
+++ b/lib/harvest/publish-bal.js
@@ -36,6 +36,7 @@ async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithE
     const publishedRevision = await publishNewRevision({codeCommune, extras, balFile, organizationName})
     return {status: 'published', publishedRevisionId: publishedRevision._id}
   } catch (error) {
+    console.error(error)
     return {status: 'error', errorMessage: error.message}
   }
 }

--- a/lib/harvest/publish-bal.js
+++ b/lib/harvest/publish-bal.js
@@ -17,7 +17,7 @@ async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithE
     return {status: 'provided-by-other-client', currentClientId: currentPublishedRevision.client.id}
   }
 
-  if (currentPublishedRevision && currentPublishedRevision.extras.sourceId !== sourceId.toString()) {
+  if (currentPublishedRevision && currentPublishedRevision.context.extras.sourceId !== sourceId.toString()) {
     return {status: 'provided-by-other-source', currentSourceId: new ObjectId(currentPublishedRevision.client.id)}
   }
 


### PR DESCRIPTION
## Contexte
Afin de déterminer si la révision courante a été publiée par une autre source (`provided-by-other-source`), la valeur `sourceId` de la révision fourni par l'API de dépôt est comparée au `sourceId` du moissonneur-bal.

Cependant, la récupération de cette variable n'est pas bonne :
`currentPublishedRevision.extras.sourceId` or, il s'agit de `currentPublishedRevision.context.extras.sourceId`