### PR TITLE
Forcer une publication

### DIFF
--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -46,7 +46,7 @@ async function createRevision({sourceId, codeCommune, harvestId, updateStatus, u
   return newRevision
 }
 
-async function publish(revision) {
+async function publish(revision, options = {}) {
   const {sourceId, codeCommune, harvestId, nbRows, nbRowsWithErrors, uniqueErrors, fileId, current} = revision
   const publication = revision.publication || {}
   const source = await Source.getSource(sourceId)
@@ -55,7 +55,7 @@ async function publish(revision) {
     throw createError(409, 'La révision n’est pas la révision courante pour cette commune')
   }
 
-  if (!['published', 'provided-by-other-client', 'provided-by-other-source'].includes(publication.status)) {
+  if (!options.force && !['published', 'provided-by-other-client', 'provided-by-other-source'].includes(publication.status)) {
     throw createError(409, 'La révision ne peut pas être publiée')
   }
 

--- a/server.js
+++ b/server.js
@@ -135,7 +135,7 @@ async function main() {
   })
 
   app.post('/revisions/:revisionId/publish', ensureIsAdmin, w(async (req, res) => {
-    const revision = await Revision.publish(req.revision)
+    const revision = await Revision.publish(req.revision, {force: req.body.force})
     res.send(revision)
   }))
 


### PR DESCRIPTION
## Contexte
Dans le cas où une erreur imprévue se produirait, il n'est actuellement pas possible de relancer la publication d'une révision. 

Cette PR ajoute une option `force` à la publication d'une révision afin de permettre la publication d'une révision qui aurait échoué à cause d'une erreur qui ne serait pas due à la donnée.