### PR TITLE
Corrige la valeur retournée par getFile

### DIFF
--- a/lib/util/mongo.js
+++ b/lib/util/mongo.js
@@ -57,7 +57,7 @@ class Mongo {
       throw new Error('Fichier introuvable')
     }
 
-    return getStream(this.bucket.openDownloadStream(fileId))
+    return getStream.buffer(this.bucket.openDownloadStream(fileId))
   }
 
   async createIndexes() {


### PR DESCRIPTION
## Contexte
La méthode `mongo.getFile` retourne actuellement une `String` hors, c'est un `Buffer` qui est attendu lors de la publication d'une révision.