### PR TITLE
Correction processus de publication

### DIFF
--- a/lib/harvest/publish-bal.js
+++ b/lib/harvest/publish-bal.js
@@ -18,7 +18,7 @@ async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithE
   }
 
   if (currentPublishedRevision && currentPublishedRevision.context.extras.sourceId !== sourceId.toString()) {
-    return {status: 'provided-by-other-source', currentSourceId: new ObjectId(currentPublishedRevision.client.id)}
+    return {status: 'provided-by-other-source', currentSourceId: new ObjectId(currentPublishedRevision.context.extras.sourceId)}
   }
 
   try {


### PR DESCRIPTION
Une coquille empêchait la construction de l'attribut `currentSourceId` lorsqu'une BAL est gérée par une autre source de données moissonnée.