### PR TITLE
Ajout d'une option "force" à publishBal

### DIFF
--- a/lib/harvest/publish-bal.js
+++ b/lib/harvest/publish-bal.js
@@ -5,18 +5,18 @@ const {getCurrentRevision, publishNewRevision} = require('../util/api-depot')
 
 const {API_DEPOT_CLIENT_ID} = process.env
 
-async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithErrors, validRows, uniqueErrors, organizationName}) {
+async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithErrors, validRows, uniqueErrors, organizationName}, options = {}) {
   if (!API_DEPOT_CLIENT_ID) {
     return {status: 'not-configured'}
   }
 
   const currentPublishedRevision = await getCurrentRevision(codeCommune)
 
-  if (currentPublishedRevision && currentPublishedRevision.client.id !== API_DEPOT_CLIENT_ID) {
+  if (!options.force && currentPublishedRevision && currentPublishedRevision.client.id !== API_DEPOT_CLIENT_ID) {
     return {status: 'provided-by-other-client', currentClientId: currentPublishedRevision.client.id}
   }
 
-  if (currentPublishedRevision && currentPublishedRevision.context.extras.sourceId !== sourceId.toString()) {
+  if (!options.force && currentPublishedRevision && currentPublishedRevision.context.extras.sourceId !== sourceId.toString()) {
     return {status: 'provided-by-other-source', currentSourceId: currentPublishedRevision.context.extras.sourceId}
   }
 

--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -96,7 +96,7 @@ async function publish(revision, options = {}) {
     validRows,
     uniqueErrors,
     organizationName
-  })
+  }, options)
 
   const {value} = await mongo.db.collection('revisions').findOneAndUpdate(
     {_id: revision._id},


### PR DESCRIPTION
## Contexte
L'option `force` mise en place pour la publication de révision n'a pas été propagée à `publishBal`, bloquant donc les révisions aux étapes de contrôle.