### PR TITLE
Suppression de Lyon Métropole de la liste blanche

### DIFF
--- a/sources.yml
+++ b/sources.yml
@@ -1,8 +1,4 @@
 whiteList:
-  - name: Base Adresse Locale de la Métropole de Lyon
-    dataset: 5be174928b4c412c5b8cc23f
-    url: https://download.data.grandlyon.com/files/grandlyon/localisation/bal/bal_200046977.csv
-
   - name: Châlons Agglomération
     converter: chalons-agglomeration
     dataset: 5c14547606e3e7530604ccef


### PR DESCRIPTION
## Contexte
La Métropole de Lyon met désormais un nouveau fichier à jour sur data.gouv.fr, il n'est donc plus utile de moissonner directement leur fichier.