### PR TITLE
Empêcher la demande d'un harvest quand la source est deleted

### DIFF
--- a/server.js
+++ b/server.js
@@ -90,6 +90,10 @@ async function main() {
       throw createError(404, 'Source inactive')
     }
 
+    if (req.source._deleted) {
+      throw createError(404, 'La source est supprimée')
+    }
+
     const source = await Source.askHarvest(req.source._id)
 
     res.status(202).send(source)


### PR DESCRIPTION
## Context

On pouvait demander un harvest lorsque que la source était supprimer.
Comme son `harvestingSince` était `null` elle n'était pas clean et comme le `_deleted` est a `true` l'Opération était toujours rejetée