### PR TITLE
Utilisation du nouvel identifiant des clients de l'API dépôt lors d'une publication concurrente

### DIFF
--- a/lib/harvest/publish-bal.js
+++ b/lib/harvest/publish-bal.js
@@ -13,7 +13,7 @@ async function publishBal({sourceId, codeCommune, harvestId, nbRows, nbRowsWithE
   const currentPublishedRevision = await getCurrentRevision(codeCommune)
 
   if (!options.force && currentPublishedRevision && currentPublishedRevision.client.id !== API_DEPOT_CLIENT_ID) {
-    return {status: 'provided-by-other-client', currentClientId: currentPublishedRevision.client.id}
+    return {status: 'provided-by-other-client', currentClientId: currentPublishedRevision.client._id}
   }
 
   if (!options.force && currentPublishedRevision && currentPublishedRevision.context.extras.sourceId !== sourceId.toString()) {

--- a/migrations/2023-03-31-migration-client-id.js
+++ b/migrations/2023-03-31-migration-client-id.js
@@ -1,0 +1,51 @@
+#!/usr/bin/env node
+require('dotenv').config()
+
+const got = require('got')
+const mongo = require('../lib/util/mongo')
+
+const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const {API_DEPOT_ADMIN_TOKEN} = process.env
+
+async function getClients() {
+  const response = await got.get(
+    `${API_DEPOT_URL}/clients`,
+    {
+      headers: {Authorization: `Token ${API_DEPOT_ADMIN_TOKEN}`},
+      responseType: 'json',
+      throwHttpErrors: false
+    }
+  )
+
+  if (response.statusCode === 200) {
+    return response.body
+  }
+
+  if (response.statusCode === 404) {
+    return
+  }
+
+  throw new Error(response.body.message)
+}
+
+async function main() {
+  await mongo.connect()
+
+  const clients = await getClients()
+  const clientsWithLegacyId = clients.filter(client => Boolean(client.id))
+
+  await Promise.all(clientsWithLegacyId.map(async client => {
+    const result = await mongo.db.collection('revisions').updateMany({'publication.currentClientId': client.id}, {$set: {'publication.currentClientId': client._id}})
+
+    if (result.modifiedCount > 0) {
+      console.log(`- ${result.modifiedCount} révisions modifiées -> Client ${client.nom}: ${client.id} => ${client._id}`)
+    }
+  }))
+
+  await mongo.disconnect()
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/migrations/2023-03-31-migration-client-id.js
+++ b/migrations/2023-03-31-migration-client-id.js
@@ -21,10 +21,6 @@ async function getClients() {
     return response.body
   }
 
-  if (response.statusCode === 404) {
-    return
-  }
-
   throw new Error(response.body.message)
 }
 


### PR DESCRIPTION
## Contexte
Lorsqu'une révision est publiée par le moissonneur, mais qu'un autre client de l'API dépôt le fait déjà pour cette commune, alors la révision obtient le statut `provided-by-other-client` qui est complété par `currentClientId`.

Cependant, `currentClientId` correspond à un ancien identifiant utilisé par l'API de dépôt, il est désormais préférable d'utiliser le nouvel identifiant `client._id`.

## Évolution
Cette PR remplace l'ancien identifiant `client.id` par le nouveau `client._id` stocké dans `publication.currentClientId`. Et prévois une migration des identifiants déjà enregistrés en base.


FIx #58