### PR TITLE
Mise à jour des URL vers l'API dépôt

### DIFF
--- a/.env.sample
+++ b/.env.sample
@@ -3,6 +3,6 @@ MONGODB_DBNAME=moissonneur-bal
 SLACK_TOKEN=
 SLACK_CHANNEL=
 ADMIN_TOKEN=
-API_DEPOT_URL=https://plateforme.adresse.data.gouv.fr/api-depot
+API_DEPOT_URL=https://plateforme-bal.adresse.data.gouv.fr/api-depot
 API_DEPOT_CLIENT_SECRET=
 API_DEPOT_CLIENT_ID=

--- a/lib/util/api-depot.js
+++ b/lib/util/api-depot.js
@@ -2,7 +2,7 @@ const got = require('got')
 const hasha = require('hasha')
 const createError = require('http-errors')
 
-const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme-bal.adresse.data.gouv.fr/api-depot'
 const {API_DEPOT_CLIENT_SECRET} = process.env
 
 async function getCurrentRevision(codeCommune) {

--- a/migrations/2023-03-31-migration-client-id.js
+++ b/migrations/2023-03-31-migration-client-id.js
@@ -4,7 +4,7 @@ require('dotenv').config()
 const got = require('got')
 const mongo = require('../lib/util/mongo')
 
-const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme.adresse.data.gouv.fr/api-depot'
+const API_DEPOT_URL = process.env.API_DEPOT_URL || 'https://plateforme-bal.adresse.data.gouv.fr/api-depot'
 const {API_DEPOT_ADMIN_TOKEN} = process.env
 
 async function getClients() {


### PR DESCRIPTION
## Contexte

Les appels vers l'API dépôt sont aujourd'hui redirigés de https://plateforme.adresse.data.gouv.fr/api-depot vers https://plateforme-bal.adresse.data.gouv.fr/api-depot.

## Évolution

Cette PR met à jour la variable d'environnement et l'URL de fallback pour pointer directement vers la nouvelle URL https://plateforme-bal.adresse.data.gouv.fr/api-depot