### PR TITLE
Degrease log useless

### DIFF
--- a/lib/worker/clean-stalled-harvests.js
+++ b/lib/worker/clean-stalled-harvests.js
@@ -1,9 +1,7 @@
 const Source = require('../models/source')
 
 async function cleanStalledHarvests() {
-  console.log('Nettoyage des moissonnages bloqués')
   await Source.cleanStalledHarvests()
-  console.log('Nettoyage des moissonnages bloqués: OK')
 }
 
 module.exports = {cleanStalledHarvests}

--- a/lib/worker/harvest-asked.js
+++ b/lib/worker/harvest-asked.js
@@ -4,16 +4,12 @@ const Source = require('../models/source')
 const {harvestSource} = require('../harvest')
 
 async function harvestAsked() {
-  console.log('Moissonnage des sources demandés par un administrateur')
-
   const sourcesToHarvest = await Source.getAskedHarvest()
   console.log(`${sourcesToHarvest.length} sources à moissonner`)
 
   await pMap(sourcesToHarvest, async source => {
     return harvestSource(source._id)
   }, {concurrency: 2})
-
-  console.log('Moissonnage des sources demandés par un administrateur: OK!')
 }
 
 module.exports = {harvestAsked}

--- a/lib/worker/harvest-new-or-outdated.js
+++ b/lib/worker/harvest-new-or-outdated.js
@@ -4,14 +4,12 @@ const Source = require('../models/source')
 const {harvestSource} = require('../harvest')
 
 async function harvestNewOrOutdated() {
-  console.log('Moissonnage des sources nouvelles et obsolètes')
   const sourcesToHarvest = await Source.findSourcesToHarvest()
   console.log(`${sourcesToHarvest.length} sources à moissonner`)
 
   await pMap(sourcesToHarvest, async source => {
     return harvestSource(source._id)
   }, {concurrency: 2})
-  console.log('Moissonnage des sources nouvelles et obsolètes: OK!')
 }
 
 module.exports = {harvestNewOrOutdated}

--- a/lib/worker/update-sources.js
+++ b/lib/worker/update-sources.js
@@ -3,11 +3,9 @@ const {computeList} = require('../sources')
 const Source = require('../models/source')
 
 async function updateSources() {
-  console.log('Mise à jour des sources de données')
   const sources = await computeList()
   await Promise.all(sources.map(async source => Source.upsert(source)))
   await Source.setOthersAsDeleted(sources.map(s => s._id))
-  console.log('Mise à jour des sources de données: OK')
 }
 
 module.exports = {updateSources}

--- a/worker.js
+++ b/worker.js
@@ -11,22 +11,22 @@ const {cleanStalledHarvests} = require('./lib/worker/clean-stalled-harvests')
 
 const jobsList = [
   {
-    name: 'mise à jour des sources de données',
+    name: 'Mise à jour des sources de données',
     every: '5m',
     handler: updateSources
   },
   {
-    name: 'nettoyage des moissonnages bloqués',
+    name: 'Nettoyage des moissonnages bloqués',
     every: '2m',
     handler: cleanStalledHarvests
   },
   {
-    name: 'moissonnage automatique des sources (nouvelles et anciennes)',
+    name: 'Moissonnage automatique des sources (nouvelles et anciennes)',
     every: '1h',
     handler: harvestNewOrOutdated
   },
   {
-    name: 'moissonnage à la demande',
+    name: 'Moissonnage à la demande',
     every: '30s',
     handler: harvestAsked
   }
@@ -34,13 +34,14 @@ const jobsList = [
 
 async function main() {
   await mongo.connect()
+  console.log('Mise à jour des sources de données')
   await updateSources()
+  console.log('Moissonnage automatique des sources (nouvelles et anciennes)')
   await harvestNewOrOutdated()
 
   jobsList.forEach(jobType => {
     setInterval(async () => {
-      const now = new Date()
-      console.log(`${now.toISOString().slice(0, 19)} | running job : ${jobType.name}`)
+      console.log(`Running job : ${jobType.name}`)
       try {
         await jobType.handler()
       } catch (error) {


### PR DESCRIPTION
## Context

Il y a beaucoup trop de logs pour chaque jobs du worker ce qui nuit a la lisibilité des logs, un simple message pour indiquer que la tache est lancée suffit