### PR TITLE
add route revision by code commune

### DIFF
--- a/lib/models/revision.js
+++ b/lib/models/revision.js
@@ -18,6 +18,10 @@ function getRevision(revisionId) {
   return mongo.db.collection('revisions').findOne({_id: revisionId})
 }
 
+function getRevisionByCodeCommune(codeCommune) {
+  return mongo.db.collection('revisions').find({codeCommune}).toArray()
+}
+
 async function createRevision({sourceId, codeCommune, harvestId, updateStatus, updateRejectionReason, fileId, dataHash, nbRows, nbRowsWithErrors, uniqueErrors, publication}) {
   const newRevision = {
     sourceId,
@@ -107,4 +111,4 @@ async function publish(revision, options = {}) {
   return value
 }
 
-module.exports = {getCurrentRevisions, createRevision, getRevisions, getRevision, publish}
+module.exports = {getCurrentRevisions, createRevision, getRevisions, getRevision, publish, getRevisionByCodeCommune}

--- a/server.js
+++ b/server.js
@@ -137,6 +137,11 @@ async function main() {
     res.send(req.revision)
   })
 
+  app.get('/communes/:codeCommune/revisions', ensureIsAdmin, w(async (req, res) => {
+    const revisions = await Revision.getRevisionByCodeCommune(req.params.codeCommune)
+    res.send(revisions)
+  }))
+
   app.post('/revisions/:revisionId/publish', ensureIsAdmin, w(async (req, res) => {
     const revision = await Revision.publish(req.revision, {force: req.body.force})
     res.send(revision)


### PR DESCRIPTION
## Context

Il n'existe pas de route pour récupérer les revisions par commune

## Fonctionnalité

Ajout de la route `communes/:codeCommune/revisions` pour récupérer les revisions d'une commune