### PR TITLE
Migration script to upload files to S3

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -60,6 +60,9 @@ typings/
 # next.js build output
 .next
 
+#migration
+./last-processed-id
+
 *.sqlite
 *.geojson
 /*.csv

--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ typings/
 .next
 
 #migration
-./last-processed-id
+last-processed-id
 
 *.sqlite
 *.geojson

--- a/migrations/2023-08-22-grid-to-s3-migration.js
+++ b/migrations/2023-08-22-grid-to-s3-migration.js
@@ -60,10 +60,7 @@ async function main() {
       console.log(`No data found for file ${fileId}`)
     } else {
       console.log(`Uploading CSV file for file ${fileId}`)
-      await s3Service.uploadS3File({
-        filename: fileId,
-        data: fileToProcess.data
-      })
+      await s3Service.uploadS3File(fileId, fileToProcess.data)
       console.log(`Upload OK, ${count} / ${total} files processed`)
     }
   }

--- a/migrations/2023-08-22-grid-to-s3-migration.js
+++ b/migrations/2023-08-22-grid-to-s3-migration.js
@@ -1,0 +1,72 @@
+#!/usr/bin/env node
+require('dotenv').config()
+const fs = require('fs')
+const getStream = require('get-stream')
+const mongo = require('../lib/util/mongo')
+const {s3Service} = require('../lib/files/s3.service')
+
+async function main() {
+  await mongo.connect()
+
+  const filesCursor = await mongo.db.collection('fs.files').find({})
+  const total = await mongo.db.collection('fs.files').estimatedDocumentCount()
+  let lastProcessedFileId = null
+
+  try {
+    lastProcessedFileId = fs.readFileSync('./last-processed-id', 'utf8')
+  } catch {
+    console.log('No last-processed-id file found, starting from the beginning')
+  }
+
+  let count = 0
+
+  for await (const file of filesCursor) {
+    count++
+
+    console.log(`Processing file : ${count} / ${total}`)
+
+    const fileId = file._id.toHexString()
+
+    if (lastProcessedFileId && lastProcessedFileId !== fileId) {
+      console.log('Last processed ID doesn\'t match, continue')
+      continue
+    } else if (lastProcessedFileId === fileId) {
+      console.log('Last processed ID matches')
+      lastProcessedFileId = null
+    }
+
+    fs.writeFileSync('./last-processed-id', fileId)
+    const fileAlreadyExists = fileId && await s3Service.checkS3FileExists(fileId)
+
+    if (fileAlreadyExists) {
+      console.log(`Skipping upload for file ${fileId}. Reason: Already uploaded`)
+      continue
+    }
+
+    console.log(`Writing metadata for file ${fileId}`)
+    await mongo.db.collection('files').insertOne({
+      _id: file._id,
+      filename: file.filename,
+      sourceId: file.metadata.sourceId,
+      harvestId: file.metadata.harvestId,
+      fileHash: file.metadata.fileHash,
+      dataHash: file.metadata.dataHash,
+    })
+
+    const data = await getStream.buffer(this.bucket.openDownloadStream(fileId))
+
+    console.log(`Uploading CSV file for file ${fileId}`)
+    await s3Service.uploadS3File({
+      filename: fileId,
+      data
+    })
+    console.log(`Upload OK, ${count} / ${total} files processed`)
+  }
+
+  await mongo.disconnect()
+}
+
+main().catch(error => {
+  console.error(error)
+  process.exit(1)
+})

--- a/migrations/2023-08-22-grid-to-s3-migration.js
+++ b/migrations/2023-08-22-grid-to-s3-migration.js
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-/* eslint-disable no-negated-condition */
+
 require('dotenv').config()
 const fs = require('fs')
 const mongo = require('../lib/util/mongo')
@@ -37,6 +37,12 @@ async function main() {
     }
 
     fs.writeFileSync('./last-processed-id', fileId)
+
+    if (!fileToProcess.data) {
+      console.log(`Error : No data found for file ${fileId}, continue`)
+      continue
+    }
+
     const fileAlreadyExistsInS3 = fileId && await s3Service.checkS3FileExists(fileId)
     const fileAlreadyExistsInMetadata = fileId && await mongo.db.collection('files').findOne({_id: file._id})
 
@@ -56,8 +62,6 @@ async function main() {
 
     if (fileAlreadyExistsInS3) {
       console.log(`File ${fileId} already exists in S3`)
-    } else if (!fileToProcess.data) {
-      console.log(`No data found for file ${fileId}`)
     } else {
       console.log(`Uploading CSV file for file ${fileId}`)
       await s3Service.uploadS3File(fileId, fileToProcess.data)


### PR DESCRIPTION
# Contexte : Migration des fichiers CSV vers stockage S3

Script de migration pour déplacer les fichiers CSV de GridFS à S3 et écrire les métadonnées dans la collection "files" plutôt que "fs.files". Pour avoir le même fonctionnement que sur API-dépôt