### PR TITLE
Fix catch error if augmentCustomEntry fail

### DIFF
--- a/lib/sources/index.js
+++ b/lib/sources/index.js
@@ -10,17 +10,22 @@ async function augmentCustomEntry(entry) {
   let dataset
   let organization
 
-  if (entry.dataset) {
-    dataset = await getDataset(entry.dataset)
-  }
+  try {
+    if (entry.dataset) {
+      dataset = await getDataset(entry.dataset)
+    }
 
-  if (entry.organization || (dataset && dataset.organization)) {
-    organization = await getOrganization(entry.organization || dataset.organization.id)
-  }
+    if (entry.organization || (dataset && dataset.organization)) {
+      organization = await getOrganization(entry.organization || dataset.organization.id)
+    }
 
-  // ADD URL TO ENTRY
-  if (!entry.url && !entry.converter && dataset) {
-    entry.url = getBALUrl(dataset)
+    // ADD URL TO ENTRY
+    if (!entry.url && !entry.converter && dataset) {
+      entry.url = getBALUrl(dataset)
+    }
+  } catch (error) {
+    console.log(`ERROR augmentCustomEntry ${entry.name}`)
+    console.log(error)
   }
 
   return {


### PR DESCRIPTION
## CONTEXT

Dans la white liste, le dataset de BAL du Grand Poitiers n'existe plus.
La fonction augmentCustomEntry (qui récupère le dataset) n'a pas de try/catch, donc throw une erreur et arrete le job updateSources.
En plus du faite que les sources ne sont jamais mis a jour, a l'initialisation le process exit completement.

## SOLUTION

Ajouter un try/catch dans la fonction augmentCustomEntry