### PR TITLE
add x-fields to request /dataset on api data.gouv

### DIFF
--- a/lib/sources/datagouv.js
+++ b/lib/sources/datagouv.js
@@ -60,8 +60,14 @@ function computeBetaGouvDatasetsUrl(page) {
 
 async function fetchDatasets(page = 1) {
   const url = computeBetaGouvDatasetsUrl(page)
-  const response = await got(url, {responseType: 'json'})
+  const options = {
+    responseType: 'json',
+    headers: {
+      'X-fields': 'total,data{id,title,description,archived,license,organization{name,page,logo,badges},resources{id,format,url,last_modified}}'
+    }
+  }
 
+  const response = await got(url, options)
   // FILTER DATASETS
   const datasets = response.body.data
     .filter(d => d.resources.some(r => isBAL(r)) && d.organization && !d.archived && isCertified(d.organization))


### PR DESCRIPTION
## CONTEXT

Il y a plusieurs request `/datasets` vers l'api data.gouv qui fail avec l'erreur `RequestError: Unexpected end of JSON input`
Après discution avec Estelle Maudet, elle nous a conseiller d'utiliser les x-fields pour réduire ces erreurs.

## FONCTIONNALITE

Ajout de X-fields dans le header pour récupérer seulement les champs dont on a besoin (cela divise par 5 le poids de la requète) 
