### PR TITLE
fix: calc code insee bal

### DIFF
--- a/lib/harvest/handle-communes-data.js
+++ b/lib/harvest/handle-communes-data.js
@@ -100,4 +100,7 @@ async function handleCommunesData({sourceId, harvestId, rows, organizationName})
   return countBy(communesRevisions, 'updateStatus')
 }
 
-module.exports = handleCommunesData
+module.exports = {
+  handleCommunesData,
+  getCodeCommune
+}

--- a/lib/harvest/handle-new-file.js
+++ b/lib/harvest/handle-new-file.js
@@ -5,7 +5,7 @@ const File = require('../models/file')
 const {signData} = require('../util/signature')
 const {communeIsInPerimeters} = require('../util/perimeters')
 
-const handleCommunesData = require('./handle-communes-data')
+const {handleCommunesData, getCodeCommune} = require('./handle-communes-data')
 
 const MAX_ALLOWED_FILE_SIZE = 100_000_000
 
@@ -59,7 +59,7 @@ async function handleNewFile(activeHarvest, file, lastCompletedHarvest, organiza
   }
 
   // CHECK PERIMETER
-  const codesCommunes = [...new Set(validRows.map(r => r.parsedValues.commune_insee))]
+  const codesCommunes = [...new Set(validRows.map(r => getCodeCommune(r)))]
   const communeOutOfPerimeters = codesCommunes
     .filter(codeCommune => !communeIsInPerimeters(codeCommune, perimeters || []))
 


### PR DESCRIPTION
## Context

- Les harvest sont `rejeté` parce que `Les codes commune sont en dehors du périmètre` ce qui n'est pas possible car il devrait y avoir le code_insee de la commune qui dépasse
- Le profile `1.3-relax` n'oblige pas a remplir `commune_insee` du fichier BAL mais lance une erreur si aucun des champ `clef-interop`, `commune_insee` n'est remplit

## Solution

- Vérifier si le commune_insee n'existe pas dans la clef_interop
