### PR TITLE
Fufeck feat harvest error

### DIFF
--- a/migrations/2024_04_18_delete_current_to_revisions.ts
+++ b/migrations/2024_04_18_delete_current_to_revisions.ts
@@ -1,0 +1,29 @@
+import { Schema, model, connect, Types } from 'mongoose';
+import * as dotenv from 'dotenv';
+dotenv.config();
+
+interface IRevision {
+  _id: any;
+  current: boolean;
+  _created: Date;
+}
+
+const revisionsSchema = new Schema<IRevision>({
+  _id: { type: Types.ObjectId },
+  current: { type: Boolean },
+});
+
+const Revision = model<IRevision>('revisions', revisionsSchema);
+
+async function migration() {
+  // CREATE organizationId
+  await Revision.updateMany({}, { $unset: { current: '' } });
+}
+
+async function run() {
+  await connect(`${process.env.MONGODB_URL}/${process.env.MONGODB_DBNAME}`);
+  await migration();
+  process.exit();
+}
+
+run().catch((err) => console.log(err));

--- a/src/modules/file/file.controller.ts
+++ b/src/modules/file/file.controller.ts
@@ -10,8 +10,8 @@ export class FileController {
 
   @Get(':fileId/download')
   @ApiOperation({
-    summary: 'Download ile',
-    operationId: 'findMany',
+    summary: 'Download file',
+    operationId: 'findOne',
   })
   @ApiParam({ name: 'fileId', required: true, type: String })
   @ApiResponse({ status: HttpStatus.OK, type: Buffer })

--- a/src/modules/harvest/harvest.service.ts
+++ b/src/modules/harvest/harvest.service.ts
@@ -35,7 +35,7 @@ export class HarvestService {
 
     if (!harvest) {
       throw new HttpException(
-        `Source ${harvestId} not found`,
+        `Harvest ${harvestId} not found`,
         HttpStatus.NOT_FOUND,
       );
     }

--- a/src/modules/revision/dto/aggregation_revision.dto.ts
+++ b/src/modules/revision/dto/aggregation_revision.dto.ts
@@ -1,8 +1,0 @@
-import { ApiProperty } from '@nestjs/swagger';
-import { Revision } from '../revision.schema';
-import { Types } from 'mongoose';
-
-export class AggregateRevision extends Revision {
-  @ApiProperty({ type: String, required: false })
-  id: Types.ObjectId;
-}

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -70,12 +70,6 @@ export class RevisionController {
     const organization = await this.organizationService.findOneOrFail(
       source.organizationId,
     );
-    if (!revison.current) {
-      throw new HttpException(
-        'La révision n’est pas la révision courante pour cette commune',
-        HttpStatus.CONFLICT,
-      );
-    }
 
     if (
       !force &&

--- a/src/modules/revision/revision.controller.ts
+++ b/src/modules/revision/revision.controller.ts
@@ -6,9 +6,6 @@ import {
   Res,
   Req,
   HttpStatus,
-  Inject,
-  forwardRef,
-  HttpException,
 } from '@nestjs/common';
 import { Response } from 'express';
 import {
@@ -19,31 +16,17 @@ import {
   ApiOperation,
   ApiBearerAuth,
 } from '@nestjs/swagger';
-import ValidateurBal from '@ban-team/validateur-bal';
+
 import { CustomRequest } from 'src/lib/types/request.type';
 import { AdminGuard } from 'src/lib/admin.guard';
 import { RevisionService } from '../revision/revision.service';
-import { Revision, StatusPublicationEnum } from '../revision/revision.schema';
+import { Revision } from '../revision/revision.schema';
 import { PublishRevisionDTO } from './dto/publish_revision.dto';
-import { SourceService } from '../source/source.service';
-import { FileService } from '../file/file.service';
-import { ApiDepotService } from '../api_depot/api_depot.service';
-import { OrganizationService } from '../organization/organization.service';
 
 @ApiTags('revisions')
 @Controller('revisions')
 export class RevisionController {
-  constructor(
-    private revisionService: RevisionService,
-    @Inject(forwardRef(() => SourceService))
-    private sourceService: SourceService,
-    @Inject(forwardRef(() => OrganizationService))
-    private organizationService: OrganizationService,
-    @Inject(forwardRef(() => FileService))
-    private fileService: FileService,
-    @Inject(forwardRef(() => ApiDepotService))
-    private apiDepotService: ApiDepotService,
-  ) {}
+  constructor(private revisionService: RevisionService) {}
 
   @Get(':revisionId')
   @ApiOperation({ summary: 'Find one revision', operationId: 'findOne' })
@@ -63,77 +46,10 @@ export class RevisionController {
   @ApiResponse({ status: HttpStatus.OK, type: Revision })
   @ApiBearerAuth('admin-token')
   @UseGuards(AdminGuard)
-  async askHarvest(@Req() req: CustomRequest, @Res() res: Response) {
-    const { force }: PublishRevisionDTO = req.body;
-    const revison: Revision = req.revision;
-    const source = await this.sourceService.findOneOrFail(revison.sourceId);
-    const organization = await this.organizationService.findOneOrFail(
-      source.organizationId,
-    );
-
-    if (
-      !force &&
-      ![
-        StatusPublicationEnum.PUBLISHED,
-        StatusPublicationEnum.PROVIDED_BY_OTHER_CLIENT,
-        StatusPublicationEnum.PROVIDED_BY_OTHER_SOURCE,
-      ].includes(revison.publication.status)
-    ) {
-      throw new HttpException(
-        'La révision ne peut pas être publiée',
-        HttpStatus.CONFLICT,
-      );
-    }
-
-    if (!source.enabled || source._deleted) {
-      throw new HttpException(
-        'La source associée n’est plus active',
-        HttpStatus.CONFLICT,
-      );
-    }
-
-    let file = null;
-    try {
-      file = await this.fileService.getFile(revison.fileId.toHexString());
-    } catch {
-      throw new HttpException(
-        'Le fichier BAL associé n’est plus disponible',
-        HttpStatus.CONFLICT,
-      );
-    }
-
-    const validationResult = await ValidateurBal.validate(file, {
-      profile: '1.3-relax',
-    });
-
-    if (
-      !validationResult.parseOk ||
-      validationResult.rows.length !== revison.nbRows
-    ) {
-      throw new HttpException(
-        'Problème de cohérence des données : investigation nécessaire',
-        HttpStatus.CONFLICT,
-      );
-    }
-
-    try {
-      // ON ESSAYE DE PUBLIER LA BAL SUR L'API-DEPOT
-      revison.publication = await this.apiDepotService.publishBal(
-        revison,
-        file,
-        organization,
-        { force },
-      );
-    } catch (error) {
-      revison.publication = {
-        status: StatusPublicationEnum.ERROR,
-        errorMessage: error.message,
-      };
-    }
-
-    const result: Revision = await this.revisionService.updateOne(
-      revison._id.toHexString(),
-      { publication: revison.publication },
+  async publish(@Req() req: CustomRequest, @Res() res: Response) {
+    const result: Revision = await this.revisionService.publish(
+      req.revision,
+      req.body.force,
     );
 
     res.status(HttpStatus.OK).json(result);

--- a/src/modules/revision/revision.schema.ts
+++ b/src/modules/revision/revision.schema.ts
@@ -82,10 +82,6 @@ export class Revision {
   @ApiProperty({ required: false })
   uniqueErrors?: string[];
 
-  @Prop({ type: SchemaTypes.Boolean })
-  @ApiProperty({ required: false })
-  current?: boolean;
-
   @Prop({ type: PublicationSchema })
   @ApiProperty({ type: () => Publication, required: false })
   publication?: Publication;

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -1,14 +1,33 @@
-import { HttpException, HttpStatus, Injectable } from '@nestjs/common';
+import {
+  HttpException,
+  HttpStatus,
+  Injectable,
+  Inject,
+  forwardRef,
+} from '@nestjs/common';
 import { InjectModel } from '@nestjs/mongoose';
 import { FilterQuery, Model, PipelineStage, QueryWithHelpers } from 'mongoose';
 
+import ValidateurBal from '@ban-team/validateur-bal';
 import { Revision, StatusPublicationEnum } from './revision.schema';
+import { SourceService } from '../source/source.service';
+import { FileService } from '../file/file.service';
+import { ApiDepotService } from '../api_depot/api_depot.service';
+import { OrganizationService } from '../organization/organization.service';
 import { StatusUpdateEnum } from 'src/lib/types/status_update.enum';
 
 @Injectable()
 export class RevisionService {
   constructor(
     @InjectModel(Revision.name) private revisionModel: Model<Revision>,
+    @Inject(forwardRef(() => SourceService))
+    private sourceService: SourceService,
+    @Inject(forwardRef(() => OrganizationService))
+    private organizationService: OrganizationService,
+    @Inject(forwardRef(() => FileService))
+    private fileService: FileService,
+    @Inject(forwardRef(() => ApiDepotService))
+    private apiDepotService: ApiDepotService,
   ) {}
 
   public async findOneOrFail(revisionId: string): Promise<Revision> {
@@ -138,5 +157,81 @@ export class RevisionService {
 
   public async createRevision(revision: Partial<Revision>): Promise<Revision> {
     return this.revisionModel.create(revision);
+  }
+
+  public async publish(
+    revision: Revision,
+    force: boolean = false,
+  ): Promise<Revision> {
+    const source = await this.sourceService.findOneOrFail(revision.sourceId);
+    const organization = await this.organizationService.findOneOrFail(
+      source.organizationId,
+    );
+
+    if (
+      !force &&
+      ![
+        StatusPublicationEnum.PUBLISHED,
+        StatusPublicationEnum.PROVIDED_BY_OTHER_CLIENT,
+        StatusPublicationEnum.PROVIDED_BY_OTHER_SOURCE,
+      ].includes(revision.publication.status)
+    ) {
+      throw new HttpException(
+        'La révision ne peut pas être publiée',
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    if (!source.enabled || source._deleted) {
+      throw new HttpException(
+        'La source associée n’est plus active',
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    let file = null;
+    try {
+      file = await this.fileService.getFile(revision.fileId.toHexString());
+    } catch {
+      throw new HttpException(
+        'Le fichier BAL associé n’est plus disponible',
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    const validationResult = await ValidateurBal.validate(file, {
+      profile: '1.3-relax',
+    });
+
+    if (
+      !validationResult.parseOk ||
+      validationResult.rows.length !== revision.nbRows
+    ) {
+      throw new HttpException(
+        'Problème de cohérence des données : investigation nécessaire',
+        HttpStatus.CONFLICT,
+      );
+    }
+
+    try {
+      // ON ESSAYE DE PUBLIER LA BAL SUR L'API-DEPOT
+      revision.publication = await this.apiDepotService.publishBal(
+        revision,
+        file,
+        organization,
+        { force },
+      );
+    } catch (error) {
+      revision.publication = {
+        status: StatusPublicationEnum.ERROR,
+        errorMessage: error.message,
+      };
+    }
+
+    const result: Revision = await this.updateOne(revision._id.toHexString(), {
+      publication: revision.publication,
+    });
+
+    return result;
   }
 }

--- a/src/modules/revision/revision.service.ts
+++ b/src/modules/revision/revision.service.ts
@@ -9,7 +9,6 @@ import {
 } from 'mongoose';
 
 import { Revision } from './revision.schema';
-import { StatusUpdateEnum } from 'src/lib/types/status_update.enum';
 
 @Injectable()
 export class RevisionService {
@@ -75,21 +74,6 @@ export class RevisionService {
   }
 
   public async createRevision(revision: Partial<Revision>): Promise<Revision> {
-    // DETERMINE SI LA REVISION QUI VA ETRE CREER VA ETRE LA COURANTE
-    const newRevision = {
-      ...revision,
-      current: [StatusUpdateEnum.UPDATED, StatusUpdateEnum.UNCHANGED].includes(
-        revision.updateStatus,
-      ),
-    };
-    // SI LA NOUVELLE REVISION EST COURANTE, LES AUTRE NE LE SONT PLUS
-    if (newRevision.current) {
-      await this.revisionModel.updateMany(
-        { sourceId: revision.sourceId, codeCommune: revision.codeCommune },
-        { $set: { current: false } },
-      );
-    }
-    // CREER LA REVISION
-    return this.revisionModel.create(newRevision);
+    return this.revisionModel.create(revision);
   }
 }

--- a/src/modules/source/dto/extended_source.dto.ts
+++ b/src/modules/source/dto/extended_source.dto.ts
@@ -1,0 +1,10 @@
+import { ApiProperty } from '@nestjs/swagger';
+import { Source } from '../source.schema';
+
+export class ExtendedSourceDTO extends Source {
+  @ApiProperty()
+  harvestError?: boolean;
+
+  @ApiProperty()
+  nbRevisionError?: number;
+}

--- a/src/modules/source/source.controller.ts
+++ b/src/modules/source/source.controller.ts
@@ -29,7 +29,7 @@ import { AdminGuard } from 'src/lib/admin.guard';
 import { UpdateSourceDTO } from './dto/update_source.dto';
 import { RevisionService } from '../revision/revision.service';
 import { HarvestService } from '../harvest/harvest.service';
-import { Harvest, StatusHarvestEnum } from '../harvest/harvest.schema';
+import { Harvest } from '../harvest/harvest.schema';
 import { PageDTO } from 'src/lib/class/page.dto';
 import { SourceHarvestsQuery } from './dto/source_harvests.query';
 import {
@@ -38,7 +38,6 @@ import {
 } from './pipe/search_query.pipe';
 import { QueueService } from '../queue/queue.service';
 import { HarvestingWorker } from '../worker/workers/harvesting.worker';
-import { StatusUpdateEnum } from 'src/lib/types/status_update.enum';
 import { ExtendedSourceDTO } from './dto/extended_source.dto';
 import { Revision } from '../revision/revision.schema';
 
@@ -64,30 +63,8 @@ export class SourceController {
     isArray: true,
   })
   async findMany(@Res() res: Response) {
-    const sources: Source[] = await this.sourceService.findMany(
-      {},
-      { _id: 1, _updated: 1, _deleted: 1, title: 1, enabled: 1 },
-    );
-
-    const harvestsInError: {
-      _id: string;
-      status: StatusHarvestEnum;
-      updateStatus: StatusUpdateEnum;
-    }[] = await this.harvestService.findErrorBySources();
-
-    const nbRevisionsInError: {
-      _id: string;
-      nbErrors: number;
-    }[] = await this.revisionService.findErrorBySources();
-
-    const extendedSources: ExtendedSourceDTO[] = sources.map((s) => {
-      return {
-        ...s,
-        harvestError: harvestsInError.some(({ _id }) => s._id === _id),
-        nbRevisionError:
-          nbRevisionsInError.find(({ _id }) => s._id === _id)?.nbErrors || 0,
-      };
-    });
+    const extendedSources: ExtendedSourceDTO[] =
+      await this.sourceService.findManyExtended();
 
     res.status(HttpStatus.OK).json(extendedSources);
   }

--- a/src/modules/source/source.controller.ts
+++ b/src/modules/source/source.controller.ts
@@ -28,7 +28,6 @@ import { CustomRequest } from 'src/lib/types/request.type';
 import { AdminGuard } from 'src/lib/admin.guard';
 import { UpdateSourceDTO } from './dto/update_source.dto';
 import { RevisionService } from '../revision/revision.service';
-import { Revision } from '../revision/revision.schema';
 import { HarvestService } from '../harvest/harvest.service';
 import { Harvest } from '../harvest/harvest.schema';
 import { PageDTO } from 'src/lib/class/page.dto';
@@ -91,21 +90,6 @@ export class SourceController {
     res.status(HttpStatus.OK).json(source);
   }
 
-  @Get(':sourceId/current-revisions')
-  @ApiOperation({
-    summary: 'Find current revisions by source',
-    operationId: 'findCurrentRevision',
-  })
-  @ApiParam({ name: 'sourceId', required: true, type: String })
-  @ApiResponse({ status: HttpStatus.OK, type: Revision, isArray: true })
-  async findCurrentRevision(@Req() req: CustomRequest, @Res() res: Response) {
-    const revisions: Revision[] = await this.revisionService.findMany({
-      sourceId: req.source._id,
-      current: true,
-    });
-    res.status(HttpStatus.OK).json(revisions);
-  }
-
   @Get(':sourceId/last-updated-revisions')
   @ApiOperation({
     summary: 'Find last revisions by source',
@@ -146,7 +130,6 @@ export class SourceController {
           nbRows: { $last: '$nbRows' },
           nbRowsWithErrors: { $last: '$nbRowsWithErrors' },
           uniqueErrors: { $last: '$uniqueErrors' },
-          current: { $last: '$current' },
           publication: { $last: '$publication' },
           _created: { $last: '$_created' },
         },

--- a/src/modules/worker/tests/harvesting.spec.ts
+++ b/src/modules/worker/tests/harvesting.spec.ts
@@ -234,7 +234,6 @@ describe('UPDATE SOURCE ORGA WORKER', () => {
         nbRows: 1,
         nbRowsWithErrors: 0,
         uniqueErrors: [],
-        current: true,
         publication: {
           status: StatusPublicationEnum.PUBLISHED,
           publishedRevisionId: revisionId.toHexString(),
@@ -324,7 +323,6 @@ describe('UPDATE SOURCE ORGA WORKER', () => {
         nbRows: 1,
         nbRowsWithErrors: 0,
         uniqueErrors: [],
-        current: true,
         publication: {
           status: StatusPublicationEnum.PUBLISHED,
           publishedRevisionId: revisionId.toHexString(),
@@ -505,7 +503,6 @@ describe('UPDATE SOURCE ORGA WORKER', () => {
         nbRows: 1,
         nbRowsWithErrors: 0,
         uniqueErrors: [],
-        current: true,
         publication: {
           status: StatusPublicationEnum.PROVIDED_BY_OTHER_CLIENT,
           currentClientId: '_other-client',
@@ -571,7 +568,6 @@ describe('UPDATE SOURCE ORGA WORKER', () => {
         nbRows: 1,
         nbRowsWithErrors: 0,
         uniqueErrors: [],
-        current: true,
         publication: {
           status: StatusPublicationEnum.PROVIDED_BY_OTHER_SOURCE,
           currentSourceId: 'other-source',

--- a/src/modules/worker/tests/update_source_organization.spec.ts
+++ b/src/modules/worker/tests/update_source_organization.spec.ts
@@ -20,6 +20,14 @@ import {
 import { ApiBetaGouvModule } from 'src/modules/api_beta_gouv/api_beta_gouv.module';
 import { SourceService } from 'src/modules/source/source.service';
 import { OrganizationService } from 'src/modules/organization/organization.service';
+import { HarvestService } from 'src/modules/harvest/harvest.service';
+import { RevisionService } from 'src/modules/revision/revision.service';
+import { Harvest, HarvestSchema } from 'src/modules/harvest/harvest.schema';
+import { Revision, RevisionSchema } from 'src/modules/revision/revision.schema';
+import { FileService } from 'src/modules/file/file.service';
+import { ApiDepotService } from 'src/modules/api_depot/api_depot.service';
+import { ConfigModule } from '@nestjs/config';
+import { HttpModule } from '@nestjs/axios';
 
 describe('UPDATE SOURCE ORGA WORKER', () => {
   //
@@ -43,17 +51,25 @@ describe('UPDATE SOURCE ORGA WORKER', () => {
 
     const moduleRef: TestingModule = await Test.createTestingModule({
       imports: [
+        ConfigModule,
+        HttpModule,
         MongooseModule.forRoot(uri),
         ApiBetaGouvModule,
         MongooseModule.forFeature([
           { name: Source.name, schema: SourceSchema },
           { name: Organization.name, schema: OrganizationSchema },
+          { name: Harvest.name, schema: HarvestSchema },
+          { name: Revision.name, schema: RevisionSchema },
         ]),
       ],
       providers: [
         UpdateSourceOrganisationWorker,
         SourceService,
         OrganizationService,
+        HarvestService,
+        RevisionService,
+        FileService,
+        ApiDepotService,
       ],
     }).compile();
 


### PR DESCRIPTION
## CONTEXT

- Le champ `current` d'une revision n'est pas pertinent car la dernière révision peut être une révision `sans changement`. De plus il empèche de publish des révisions qui ne sont pas `current == true`

- Il est compliqué de voir les erreurs pour les harvest et révision

## FONCTIONNALITE

- Faire sauter la notion de revision current inutile

- Ajout d'aggregation sur la route /sources pour récupérer les erreurs des harvests et revisions de chaque source