### PR TITLE
feat: extend sources of organizations

### DIFF
--- a/src/modules/organization/organization.controller.ts
+++ b/src/modules/organization/organization.controller.ts
@@ -25,6 +25,7 @@ import { OrganizationService } from './organization.service';
 import { Organization } from './organization.schema';
 import { UpdateOrganizationDTO } from './dto/update_organization.dto';
 import { Source } from '../source/source.schema';
+import { ExtendedSourceDTO } from '../source/dto/extended_source.dto';
 
 @ApiTags('organizations')
 @Controller('organizations')
@@ -82,12 +83,18 @@ export class OrganizationController {
     operationId: 'findSources',
   })
   @ApiParam({ name: 'organizationId', required: true, type: String })
-  @ApiResponse({ status: HttpStatus.OK, type: Source, isArray: true })
+  @ApiResponse({
+    status: HttpStatus.OK,
+    type: ExtendedSourceDTO,
+    isArray: true,
+  })
   async findSources(@Req() req: CustomRequest, @Res() res: Response) {
     const sources: Source[] = await this.sourceService.findMany(
       { organizationId: req.organization._id },
       { _id: 1, _updated: 1, _deleted: 1, title: 1, enabled: 1 },
     );
-    res.status(HttpStatus.OK).json(sources);
+    const extendedSources: ExtendedSourceDTO[] =
+      await this.sourceService.extendMany(sources);
+    res.status(HttpStatus.OK).json(extendedSources);
   }
 }

--- a/src/modules/source/source.controller.ts
+++ b/src/modules/source/source.controller.ts
@@ -63,8 +63,12 @@ export class SourceController {
     isArray: true,
   })
   async findMany(@Res() res: Response) {
+    const sources: Source[] = await this.sourceService.findMany(
+      {},
+      { _id: 1, _updated: 1, _deleted: 1, title: 1, enabled: 1 },
+    );
     const extendedSources: ExtendedSourceDTO[] =
-      await this.sourceService.findManyExtended();
+      await this.sourceService.extendMany(sources);
 
     res.status(HttpStatus.OK).json(extendedSources);
   }

--- a/src/modules/source/source.service.ts
+++ b/src/modules/source/source.service.ts
@@ -50,12 +50,7 @@ export class SourceService {
     return query.lean().exec();
   }
 
-  async findManyExtended(): Promise<ExtendedSourceDTO[]> {
-    const sources: Source[] = await this.findMany(
-      {},
-      { _id: 1, _updated: 1, _deleted: 1, title: 1, enabled: 1 },
-    );
-
+  public async extendMany(sources: Source[]): Promise<ExtendedSourceDTO[]> {
     const harvestsInError: {
       _id: string;
       status: StatusHarvestEnum;


### PR DESCRIPTION
## Context

Pour la PR https://github.com/BaseAdresseNationale/adresse.data.gouv.fr/pull/1732 on a besoin d'avoir les erreurs pour les sources d'une organization, donc d'étendre les retour de la route `/:organizationId/sources`