### PR TITLE
fix: change badge orgnizations datagouv

### DIFF
--- a/src/modules/api_beta_gouv/api_beta_gouv.service.ts
+++ b/src/modules/api_beta_gouv/api_beta_gouv.service.ts
@@ -12,7 +12,8 @@ import {
 const PAGE_SIZE = 100;
 const TAG = 'base-adresse-locale';
 const FORMAT = 'csv';
-const BADGES_ACCEPTED = ['certified', 'public-service'];
+const BADGES_CERTIFIED = 'certified';
+const BADGES_ONE_OF_REQUIRED = ['local-authority', 'public-service'];
 
 @Injectable()
 export class ApiBetaGouvService {
@@ -21,8 +22,11 @@ export class ApiBetaGouvService {
   private isCertifiedOrganization(organization: OrganizationDataGouv): boolean {
     const { badges } = organization;
 
-    return BADGES_ACCEPTED.every((badge: string) =>
-      badges.some(({ kind }) => kind === badge),
+    return (
+      badges.some(({ kind }) => kind === BADGES_CERTIFIED) &&
+      BADGES_ONE_OF_REQUIRED.some((badge: string) =>
+        badges.some(({ kind }) => kind === badge),
+      )
     );
   }
 

--- a/src/modules/api_beta_gouv/api_beta_gouv.service.ts
+++ b/src/modules/api_beta_gouv/api_beta_gouv.service.ts
@@ -12,7 +12,7 @@ import {
 const PAGE_SIZE = 100;
 const TAG = 'base-adresse-locale';
 const FORMAT = 'csv';
-const BADGES_CERTIFIED = 'certified';
+const BADGE_CERTIFIED = 'certified';
 const BADGES_ONE_OF_REQUIRED = ['local-authority', 'public-service'];
 
 @Injectable()
@@ -23,7 +23,7 @@ export class ApiBetaGouvService {
     const { badges } = organization;
 
     return (
-      badges.some(({ kind }) => kind === BADGES_CERTIFIED) &&
+      badges.some(({ kind }) => kind === BADGE_CERTIFIED) &&
       BADGES_ONE_OF_REQUIRED.some((badge: string) =>
         badges.some(({ kind }) => kind === badge),
       )


### PR DESCRIPTION
## Context

Maintenant lorsqu'une orgnisation a les deux badge 'local-authority', 'public-service' elle ne garde que le badge 'local-authority' et était donc exclu des organisation qu'on moissonnait.